### PR TITLE
feature: update logging and messages

### DIFF
--- a/src/ezmodeller/model_constraint.py
+++ b/src/ezmodeller/model_constraint.py
@@ -85,7 +85,7 @@ class ModelConstraint(Generic[D]):
 
         if len(missing_variables):
             raise OptimizationModelMissingVariablesError(
-                f"The following required variables are not defined in the model: {', '.join(missing_variables)}"
+                f"The following variables required by symbolic constraint {self.name} are not defined in the model: {', '.join(missing_variables)}"
             )
 
     def get_gurobi_constraints_generator(self, input_data, variables):

--- a/src/ezmodeller/model_constraint.py
+++ b/src/ezmodeller/model_constraint.py
@@ -74,6 +74,9 @@ class ModelConstraint(Generic[D]):
                 f"No set_constraint_properties function defined in constraint class {self.__class__.__module__ + '.' +self.__class__.__qualname__}"
             )
 
+        if self.name == "":
+            self.name = self.__class__.__qualname__
+
         missing_variables = [
             x
             for x in self.required_variables
@@ -84,9 +87,6 @@ class ModelConstraint(Generic[D]):
             raise OptimizationModelMissingVariablesError(
                 f"The following required variables are not defined in the model: {', '.join(missing_variables)}"
             )
-
-        if self.name == "":
-            self.name = self.__class__.__qualname__
 
     def get_gurobi_constraints_generator(self, input_data, variables):
         """Function that needs to be implemented to return the generator that creates

--- a/src/ezmodeller/optimization_model.py
+++ b/src/ezmodeller/optimization_model.py
@@ -389,6 +389,9 @@ class OptimizationModel:
 
         # Use sorted here to ensure we always loop over the constraints in the same way
         for _constraint_name in sorted(self.constraints.keys()):
+            logger.debug(
+                f"Going to generate constraints for symbolic constraint {_constraint_name}"
+            )
             # Reset the access counter we use to check which variables the user used
             for _var in self.variables.keys():
                 self.variable_accessed[_var] = 0


### PR DESCRIPTION
In case an error happened during the generating of the constraint, it was not always clear during the generation of which constraint the error occurred. In order to solve this, we now will print the name of the constraint beforehand.